### PR TITLE
Get imx vpu supported profiles to fix the video decoder initalization

### DIFF
--- a/patches/common/0002-Add-VPU-video-decode-accelerator-to-Chromium-GPU-.patch
+++ b/patches/common/0002-Add-VPU-video-decode-accelerator-to-Chromium-GPU-.patch
@@ -57,23 +57,34 @@ Signed-off-by: Carlos Rafael Giani <dv@pseudoterminal.org>
        &GpuVideoDecodeAccelerator::CreateV4L2VDA,
        &GpuVideoDecodeAccelerator::CreateV4L2SliceVDA,
        &GpuVideoDecodeAccelerator::CreateVaapiVDA,
-@@ -296,6 +299,16 @@
+@@ -296,6 +299,18 @@
    return decoder.Pass();
  }
  
 +scoped_ptr<media::VideoDecodeAccelerator>
 +GpuVideoDecodeAccelerator::CreateImxVpuVDA() {
 +  scoped_ptr<media::VideoDecodeAccelerator> decoder;
++#if defined(IMX_PLATFORM)
 +  DVLOG(0) << "Using the i.MX6 VPU decode accelerator";
 +  decoder.reset(new ImxVpuVideoDecodeAccelerator(
 +      stub_->decoder()->AsWeakPtr(),
 +      make_context_current_));
++#endif
 +  return decoder.Pass();
 +}
 +
  scoped_ptr<media::VideoDecodeAccelerator>
  GpuVideoDecodeAccelerator::CreateV4L2VDA() {
    scoped_ptr<media::VideoDecodeAccelerator> decoder;
+@@ -414,6 +414,8 @@
+   profiles = VTVideoDecodeAccelerator::GetSupportedProfiles();
+ #elif defined(OS_ANDROID)
+   profiles = AndroidVideoDecodeAccelerator::GetSupportedProfiles();
++#elif defined(IMX_PLATFORM)
++  profiles = ImxVpuVideoDecodeAccelerator::GetSupportedProfiles();
+ #endif
+   return GpuVideoAcceleratorUtil::ConvertMediaToGpuDecodeProfiles(profiles);
+ }
 --- a/content/content_common.gypi
 +++ b/content/content_common.gypi
 @@ -782,6 +782,40 @@

--- a/src/content/common/gpu/media/imxvpu_video_decode_accelerator.cc
+++ b/src/content/common/gpu/media/imxvpu_video_decode_accelerator.cc
@@ -68,6 +68,14 @@ private:
 
 } // unnamed namespace end
 
+static const media::VideoCodecProfile kSupportedProfiles[] = {
+	media::H264PROFILE_BASELINE,
+	media::H264PROFILE_MAIN,
+	media::H264PROFILE_HIGH,
+	media::H264PROFILE_MAX,
+	media::VP8PROFILE_ANY,
+};
+
 
 ImxVpuVideoDecodeAccelerator::ImxVpuVideoDecodeAccelerator(base::WeakPtr < gpu::gles2::GLES2Decoder > const gles2_decoder, base::Callback < bool(void) > const &make_context_current)
 	: gles2_decoder_(gles2_decoder)
@@ -321,6 +329,22 @@ void ImxVpuVideoDecodeAccelerator::Destroy()
 	DCHECK_EQ(message_loop_, base::MessageLoop::current());
 	Cleanup();
 	delete this;
+}
+
+
+// static
+media::VideoDecodeAccelerator::SupportedProfiles
+ImxVpuVideoDecodeAccelerator::GetSupportedProfiles()
+{
+    SupportedProfiles profiles;
+    for (const auto& supported_profile : kSupportedProfiles) {
+		SupportedProfile profile;
+		profile.profile = supported_profile;
+		profile.min_resolution.SetSize(64, 64);
+		profile.max_resolution.SetSize(1920, 1088);
+		profiles.push_back(profile);
+    }
+	return profiles;
 }
 
 

--- a/src/content/common/gpu/media/imxvpu_video_decode_accelerator.h
+++ b/src/content/common/gpu/media/imxvpu_video_decode_accelerator.h
@@ -41,6 +41,7 @@ public:
 	virtual void Destroy() override;
 	virtual bool CanDecodeOnIOThread() override;
 
+    static media::VideoDecodeAccelerator::SupportedProfiles GetSupportedProfiles();
 
 private:
 	enum ProcessRetval


### PR DESCRIPTION
The problem is the i.MX VPU which returns no profile, so the video decode initialization failed, and the videos weren't decoded by HW. 
The modifications implement the function GetSupportedProfiles() which is called during video decoder initialization to check if the video profile is supported by the VPU.
